### PR TITLE
Update requirement for six library:  >=1.11,<2.0

### DIFF
--- a/travis-textract-requirements/python.txt
+++ b/travis-textract-requirements/python.txt
@@ -12,5 +12,5 @@ xlrd==1.0.0
 EbookLib==0.16
 SpeechRecognition==3.7.1
 https://github.com/mattgwwalker/msg-extractor/zipball/master
-six==1.10.0
+six>=1.11,<2.0
 pocketsphinx==0.1.3


### PR DESCRIPTION
>=1.11,<2.0 is the current Wagtail requirement for six